### PR TITLE
Color handling fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # ExportHtml
 
+## 2.15.1
+
+- **FIX**: ST4 now handles `HSL` properly, remove workaround for build 4069.
+- **FIX**: `+`/`-` have to be followed by spaces in `saturation`, `lightness`, and `alpha` or they should be treated as
+  part of the number following them. `*` does not need a space.
+- **FIX**: Add support for `deg` unit type for the hue channel with `HSL` and `HWB`.
+- **FIX**: Sublime will ignore the unit types `rad`, `grad`, and `turn` for `HSL` and `HWB`, but add support for them in
+  case Sublime ever does.
+
 ## 2.15.0
 
 - **NEW**: Support `lightness()` and `saturation()` in color mod functions.

--- a/lib/color_scheme_matcher.py
+++ b/lib/color_scheme_matcher.py
@@ -34,10 +34,14 @@ from os import path
 from collections import namedtuple
 from plistlib import readPlistFromBytes
 import decimal
+import math
 
 NEW_SCHEMES = int(sublime.version()) >= 3150
 FONT_STYLE = "font_style" if int(sublime.version()) >= 3151 else "fontStyle"
 GLOBAL_OPTIONS = "globals" if int(sublime.version()) >= 3152 else "defaults"
+
+CONVERT_TURN = 360
+CONVERT_GRAD = 90 / 100
 
 # XML
 XML_COMMENT_RE = re.compile(br"^[\r\n\s]*<!--[\s\S]*?-->[\s\r\n]*|<!--[\s\S]*?-->")
@@ -47,7 +51,8 @@ FLOAT_TRIM_RE = re.compile(r'^(?P<keep>\d+)(?P<trash>\.0+|(?P<keep2>\.\d*[1-9])0
 
 COLOR_PARTS = {
     "percent": r"[+\-]?(?:(?:\d*\.\d+)|\d+)%",
-    "float": r"[+\-]?(?:(?:\d*\.\d+)|\d+)"
+    "float": r"[+\-]?(?:(?:\d*\.\d+)|\d+)",
+    "angle": r"[+\-]?(?:(?:\d*\.\d+)|\d+)(deg|rad|turn|grad)?"
 }
 
 RGB_COLORS = r"""(?x)
@@ -63,11 +68,11 @@ RGB_COLORS = r"""(?x)
 
 HSL_COLORS = r"""(?x)
     \b(?P<hsl>hsl\(\s*(?P<hsl_content>%(float)s\s*,\s*%(percent)s\s*,\s*%(percent)s)\s*\)) |
-    \b(?P<hsla>hsla\(\s*(?P<hsla_content>%(float)s\s*,\s*(?:%(percent)s\s*,\s*){2}(?:%(percent)s|%(float)s))\s*\))
+    \b(?P<hsla>hsla\(\s*(?P<hsla_content>%(angle)s\s*,\s*(?:%(percent)s\s*,\s*){2}(?:%(percent)s|%(float)s))\s*\))
 """ % COLOR_PARTS
 
 HWB_COLORS = r"""(?x)
-    \b(?P<hwb>hwb\(\s*(?P<hwb_content>%(float)s\s*,\s*%(percent)s\s*,\s*%(percent)s
+    \b(?P<hwb>hwb\(\s*(?P<hwb_content>%(angle)s\s*,\s*%(percent)s\s*,\s*%(percent)s
     (?:\s*,\s*(?:%(percent)s|%(float)s))?)\s*\))
 """ % COLOR_PARTS
 
@@ -111,16 +116,16 @@ COLOR_MOD_RE = re.compile(
                 (?P<blend_color>\#[\dA-Fa-f]{8}|\#[\dA-Fa-f]{6})\s+
                 (?P<blend_percent>%(percent)s)
                 (?:\s+(?P<blend_mode>hsl|rgb|hwb))?\) |
-            (?P<alpha>a(?:lpha)?)\(\s*(?P<alpha_op>[\+\-\*]\s*)?(?P<alpha_value>(?:%(percent)s|%(float)s))\s*\) |
-            (?P<sat>s(?:aturation)?)\(\s*(?P<sat_op>[\+\-\*]\s*)?(?P<sat_value>(?:%(percent)s|%(float)s))\s*\) |
-            (?P<lit>l(?:ightness)?)\(\s*(?P<lit_op>[\+\-\*]\s*)?(?P<lit_value>(?:%(percent)s|%(float)s))\s*\)
+            (?P<alpha>a(?:lpha)?)\(\s*(?P<alpha_op>[\+\-]\s+|\*\s*)?(?P<alpha_value>(?:%(percent)s|%(float)s))\s*\) |
+            (?P<sat>s(?:aturation)?)\(\s*(?P<sat_op>[\+\-]\s+|\*\s*)?(?P<sat_value>(?:%(percent)s))\s*\) |
+            (?P<lit>l(?:ightness)?)\(\s*(?P<lit_op>[\+\-]\s+|\*\s*)?(?P<lit_value>(?:%(percent)s))\s*\)
         )
         (?P<other>(?:
             \s+(?:
                 blenda?\((?:\#[\dA-Fa-f]{8}|\#[\dA-Fa-f]{6})\s+%(percent)s(?:\s+(?:hsl|rgb|hwb))?\) |
-                a(?:lpha)?\(\s*(?:[\+\-\*]\s*)?(?:%(percent)s|%(float)s)\s*\) |
-                s(?:aturation)?\(\s*(?:[\+\-\*]\s*)?(?:%(percent)s|%(float)s)\s*\) |
-                l(?:ightness)?\(\s*(?:[\+\-\*]\s*)?(?:%(percent)s|%(float)s)\s*\)
+                a(?:lpha)?\(\s*(?:[\+\-]\s+|\*\s*)?(?:%(percent)s|%(float)s)\s*\) |
+                s(?:aturation)?\(\s*(?:[\+\-]\s+|\*\s*)?(?:%(percent)s)\s*\) |
+                l(?:ightness)?\(\s*(?:[\+\-]\s+|\*\s*)?(?:%(percent)s)\s*\)
             )
         )+)?
     \s*\)
@@ -135,6 +140,22 @@ OP_MAP = {
     '+': OP_ADD,
     '-': OP_SUB
 }
+
+
+def norm_angle(angle):
+    """Normalize angle units."""
+
+    if angle.endswith('turn'):
+        value = float(angle[:-4]) * CONVERT_TURN
+    elif angle.endswith('rad'):
+        value = math.degrees(float(angle[:-3]))
+    elif angle.endswith('grad'):
+        value = float(angle[:-3]) * CONVERT_GRAD
+    elif angle.endswith('deg'):
+        value = float(angle[:-3])
+    else:
+        value = float(angle)
+    return value
 
 
 def packages_path(pth):
@@ -226,20 +247,14 @@ def blend(m, limit=False):
     elif m.group('sat_value'):
         percent = m.group('sat_value')
         op = OP_MAP[m.group('sat_op').strip() if m.group('sat_op') else '']
-        if percent.endswith('%'):
-            percent = float(percent.rstrip('%')) / 100.0
-        else:
-            percent = float(percent)
+        percent = float(percent.rstrip('%')) / 100.0
         rgba = RGBA(base)
         rgba.saturation(percent, op)
         color = rgba.get_rgb() if rgba.a == 255 else rgba.get_rgba()
     elif m.group('lit_value'):
         percent = m.group('lit_value')
         op = OP_MAP[m.group('lit_op').strip() if m.group('lit_op') else '']
-        if percent.endswith('%'):
-            percent = float(percent.rstrip('%')) / 100.0
-        else:
-            percent = float(percent)
+        percent = float(percent.rstrip('%')) / 100.0
         rgba = RGBA(base)
         rgba.luminance(percent, op)
         color = rgba.get_rgb() if rgba.a == 255 else rgba.get_rgba()
@@ -323,9 +338,9 @@ def translate_color(m, var, var_src):
             else:
                 alpha = alpha_dec_normalize(content[3])
         elif groups.get('hsl'):
-            content = [x.strip() for x in m.group('hsl_content').split(',')]
+            content = [x.strip().lower() for x in m.group('hsl_content').split(',')]
             rgba = RGBA()
-            hue = float(content[0])
+            hue = norm_angle(content[0])
             if hue < 0.0 or hue > 360.0:
                 hue = hue % 360.0
             h = hue / 360.0

--- a/lib/rgba.py
+++ b/lib/rgba.py
@@ -7,6 +7,9 @@ Copyright (c) 2012 - 2016 Isaac Muse <isaacmuse@gmail.com>
 import re
 from colorsys import rgb_to_hls, hls_to_rgb, rgb_to_hsv, hsv_to_rgb
 import decimal
+import sublime
+
+HSL_WORKAROUND = int(sublime.version()) < 4069
 
 RGB_CHANNEL_SCALE = 1.0 / 255.0
 HUE_SCALE = 1.0 / 360.0
@@ -54,8 +57,10 @@ def hue_blend_channel(c1, c2, f):
             c1 += 360.0
         else:
             c2 += 360.0
-    # This shouldn't be necessary and is probably a bug in Sublime.
-    f = 1.0 - f
+
+    if HSL_WORKAROUND:
+        # This shouldn't be necessary and is probably a bug in Sublime.
+        f = 1.0 - f
 
     value = abs(c1 * f + c2 * (1 - f))
     while value > 360.0:

--- a/support.py
+++ b/support.py
@@ -5,7 +5,7 @@ import textwrap
 import webbrowser
 import re
 
-__version__ = "2.15.0"
+__version__ = "2.15.1"
 __pc_name__ = 'ExportHtml'
 
 CSS = '''


### PR DESCRIPTION
- ST4 now handles HSL properly, remove workaround for build 4069
- +/- have to be followed by spaces or they should be treated as part of
the number following them. * does not need a space.
- Add support for `deg` unit.
- Sublime will ignore the unit types: `rad`, `grad`, and `turn`, but add
  support for them in case Sublime ever does.

closes #67 