### PR TITLE
Move export to HTML option to top-level context menu

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -1,12 +1,6 @@
 [
     { "caption": "-" },
-    {
-        "caption": "Export",
-        "children":
-        [
-            { "command": "export_html_panel", "caption": "HTML" }
-        ]
-    },
+    { "command": "export_html_panel", "caption": "Export to HTML" },
     {
         "caption": "Annotations",
         "children":


### PR DESCRIPTION
After dropping the support of exporting to BBCode, HTML is the only child option under the "Export" context menu option, so I think it's better to move it to the top-level context menu.